### PR TITLE
fix: Enhance workflow to cache conda environments and add manual trigger

### DIFF
--- a/.github/workflows/fetch_metadata.yml
+++ b/.github/workflows/fetch_metadata.yml
@@ -2,10 +2,11 @@ name: Update NCBI metadata
 
 on:
   schedule:
-      - cron:  '0 0 */7 * *'
+      - cron: '0 0 */7 * *'
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.repository }}
@@ -29,7 +30,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: ./.github/actions/install-dependencies
+      - name: Cache envs
+        id: cache-envs
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.NXF_WORK }}/conda
+            $CONDA_PREFIX/envs
+          key: env-${{ env.NXF_VER }}-${{ github.job }}
+          restore-keys: |
+            env-${{ env.NXF_VER }}-${{ github.job }}
+            env-${{ env.NXF_VER }}
+            env-
+      - name: 'Check and setup conda environment'
+        run: mamba env update --name freyja-sra --file environment.yml --prune && mamba activate freyja-sra
       - name: Fetch NCBI metadata
         run: python scripts/fetch_sra_metadata.py
 


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration to improve efficiency and flexibility. The key changes involve adding manual workflow dispatch capability and implementing caching for environment dependencies.

Workflow improvements:

* [`.github/workflows/fetch_metadata.yml`](diffhunk://#diff-811af44d797ce1ee4dd482e34cdb7f93402f69e58caf11c94adbccf23a9509fbR9): Added `workflow_dispatch` to allow manual triggering of the workflow.

Caching and dependency management:

* [`.github/workflows/fetch_metadata.yml`](diffhunk://#diff-811af44d797ce1ee4dd482e34cdb7f93402f69e58caf11c94adbccf23a9509fbL32-R46): Replaced the custom action `install-dependencies` with caching steps for conda environments using `actions/cache@v4` and a new step to check and set up the conda environment.