### PR TITLE
fix: downgrade Python version to 3.10 and add pip dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,12 +6,13 @@ dependencies:
   - bioconda::cutadapt=4.4
   - bioconda::freyja=1.5.1
   - bioconda::minimap2=2.26
-  - conda-forge::python=3.11
+  - conda-forge::python=3.10
   - conda-forge::awscli
   - conda-forge::pyarrow
   - conda-forge::google-cloud-sdk=458.0.1
   - conda-forge::procps-ng=3.3.17
   - hcc::aspera-cli
+  - pip
   - pip:
     - ffq
     - epiweeks


### PR DESCRIPTION
This pull request includes changes to the `environment.yml` file, specifically modifying the dependencies to ensure compatibility and adding a new dependency.

Dependency modifications:

* Changed the Python version from `3.11` to `3.10` to ensure compatibility with other dependencies.
* Added `pip` to the list of dependencies to facilitate the installation of packages listed under `pip`.