### PR TITLE
fix: Update workflow to separate mamba commands for better readability

### DIFF
--- a/.github/workflows/fetch_metadata.yml
+++ b/.github/workflows/fetch_metadata.yml
@@ -43,7 +43,9 @@ jobs:
             env-${{ env.NXF_VER }}
             env-
       - name: 'Check and setup conda environment'
-        run: mamba env update --name freyja-sra --file environment.yml --prune && mamba activate freyja-sra
+        run: | 
+          mamba env update --name freyja-sra --file environment.yml --prune
+          mamba activate freyja-sra
       - name: Fetch NCBI metadata
         run: python scripts/fetch_sra_metadata.py
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/fetch_metadata.yml` file. The change modifies the `Check and setup conda environment` step to split the `run` command into two separate lines for better readability.

* [`.github/workflows/fetch_metadata.yml`](diffhunk://#diff-811af44d797ce1ee4dd482e34cdb7f93402f69e58caf11c94adbccf23a9509fbL46-R48): Split the `run` command in `Check and setup conda environment` step into two lines for clarity.