### PR TITLE
fix: Activate conda environment before fetching NCBI metadata

### DIFF
--- a/.github/workflows/fetch_metadata.yml
+++ b/.github/workflows/fetch_metadata.yml
@@ -45,9 +45,10 @@ jobs:
       - name: 'Check and setup conda environment'
         run: | 
           mamba env update --name freyja-sra --file environment.yml --prune
-          mamba activate freyja-sra
       - name: Fetch NCBI metadata
-        run: python scripts/fetch_sra_metadata.py
+        run: |
+          mamba activate freyja-sra
+          python scripts/fetch_sra_metadata.py
 
       - name: 'Get updated barcodes and lineages from Freyja repo'
         run: |


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/fetch_metadata.yml` file. The change ensures the conda environment is activated before running the script to fetch NCBI metadata.

* [`.github/workflows/fetch_metadata.yml`](diffhunk://#diff-811af44d797ce1ee4dd482e34cdb7f93402f69e58caf11c94adbccf23a9509fbL48-R51): Moved the `mamba activate freyja-sra` command to ensure the conda environment is activated before running the `fetch_sra_metadata.py` script.