### PR TITLE
Fix path for git clone in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Automated SRA downloading, processing and [Freyja](https://github.com/andersen-l
 
 ## Installation
 ```bash
-git clone https://github.com/dylanpilz/freyja-sc2.git
+git clone https://github.com/andersen-lab/Freyja-SC2.git
 cd freyja-sc2
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Automated SRA downloading, processing and [Freyja](https://github.com/andersen-l
 ## Installation
 ```bash
 git clone https://github.com/andersen-lab/Freyja-SC2.git
-cd freyja-sc2
+cd Freyja-SC2
 ```
 
 ## Usage


### PR DESCRIPTION
Should fix this:

```
git clone https://github.com/dylanpilz/freyja-sc2.git
cd freyja-sc2
Cloning into 'freyja-sc2'...
remote: Repository not found.
fatal: repository 'https://github.com/dylanpilz/freyja-sc2.git/' not found
cd: no such file or directory: freyja-sc2
```