### PR TITLE
feat(dependabot): Add Dependabot support for github actions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Keep GitHub Actions used by the workflows and the composite action up to date.
+  - package-ecosystem: "github-actions"
+    directories:
+      - "/"
+      - "/.github/actions/*"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+    commit-message:
+      prefix: "ci"
+    open-pull-requests-limit: 5
+    groups:
+      # Batch low-risk bumps into a single PR; major bumps get their own PR.
+      actions-minor:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
This pull request introduces a new `.github/dependabot.yml` configuration file to automate dependency updates for GitHub Actions in the repository. The configuration ensures that actions are kept up to date on a monthly schedule, with minor and patch updates batched together for easier review.

Dependency management automation:

* Added `.github/dependabot.yml` to configure Dependabot for GitHub Actions, scheduling monthly updates (on Mondays), batching minor and patch updates into grouped pull requests, and limiting open PRs to five at a time.